### PR TITLE
Make economy check sync - fixes #47

### DIFF
--- a/src/main/java/randy/epicquest/EpicMain.java
+++ b/src/main/java/randy/epicquest/EpicMain.java
@@ -207,19 +207,14 @@ public class EpicMain extends JavaPlugin{
 	}
 
 	private void setupEconomy(){
-		Bukkit.getScheduler().scheduleSyncDelayedTask(EpicMain.getInstance(), new Runnable(){
-			@Override
-			public void run() {
-				RegisteredServiceProvider<Economy> economyProvider = getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
-				if (economyProvider != null && economyProvider.getProvider().isEnabled()) {
-					economy = economyProvider.getProvider();
-				}else{
-					//Economy not used or found
-					EpicSystem.setEnabledMoneyRewards(false);
-					System.out.print("[EpicQuest] Couldn't find an economy plugin through Vault, deactivated currency rewards.");
-				}
-			}
-		}, 50);
+		RegisteredServiceProvider<Economy> economyProvider = getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
+		if (economyProvider != null && economyProvider.getProvider().isEnabled()) {
+			economy = economyProvider.getProvider();
+		}else{
+			//Economy not used or found
+			EpicSystem.setEnabledMoneyRewards(false);
+			System.out.print("[EpicQuest] Couldn't find an economy plugin through Vault, deactivated currency rewards.");
+		}
 	}
 
 	private boolean setupHeroes(){


### PR DESCRIPTION
The async check was causing a NPE to be thrown when a player joined the server before it could run.
Also, there is no need to make this check async.